### PR TITLE
Add GitHub Actions deployment workflow for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build the app
+        run: npm run build
+
+      - name: Set Git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow for deploying the application to GitHub Pages. The workflow automates the build and deployment process whenever changes are pushed to the `master` branch.

Deployment workflow:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R1-R39): Created a new workflow named "Deploy to GitHub Pages" that runs on `ubuntu-latest`. It includes steps for checking out the repository, setting up Node.js (version 18), installing dependencies, building the app, configuring Git identity, and deploying the `./dist` directory to GitHub Pages using the `peaceiris/actions-gh-pages` action.