### PR TITLE
Enable HTTPS for local dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+certs/
+

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm run dev
 ```
 
 Then open:
-👉 http://localhost:5173
+👉 https://localhost:5173/PlaylistRadar
 
 
 🌐 Deploy to GitHub Pages

--- a/README.md
+++ b/README.md
@@ -29,8 +29,17 @@ cd PlaylistRadar
 ```bash
 npm install
 ```
+### 3. Install local SSL certificate
 
-### 3. Start the development server
+```bash
+brew install mkcert
+brew install nss    # (optional, for Firefox)
+mkcert -install
+mkcert localhost
+```
+move them into certs folder
+
+### 4. Start the development server
 
 ```bash
 npm run dev
@@ -38,6 +47,8 @@ npm run dev
 
 Then open:
 👉 https://localhost:5173/PlaylistRadar
+
+
 
 
 🌐 Deploy to GitHub Pages

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,5 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: "/PlaylistRadar/"
+  base: "/PlaylistRadar/",
+  server: {
+    https: true,
+    open: '/PlaylistRadar/'
+  }
 })

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,12 +1,15 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import fs from 'fs';
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: "/PlaylistRadar/",
+  base: '/PlaylistRadar/',
   server: {
-    https: true,
+    https: {
+      key: fs.readFileSync('./certs/localhost-key.pem'),
+      cert: fs.readFileSync('./certs/localhost.pem')
+    },
     open: '/PlaylistRadar/'
   }
-})
+});


### PR DESCRIPTION
## Summary
- configure Vite dev server to use HTTPS
- update README to open the dev site over HTTPS

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_684b625eb25c83278f60c6a20989853b